### PR TITLE
Make it possible to specify number of processes

### DIFF
--- a/qgis-exec/Dockerfile
+++ b/qgis-exec/Dockerfile
@@ -17,6 +17,7 @@ COPY deb/libqgis-analysis*.deb \
 
 RUN apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
+        multiwatch \
         spawn-fcgi \
         xauth \
         xvfb \
@@ -34,9 +35,11 @@ ENV QGIS_SERVER_LOG_FILE /var/log/qgisserver.log
 ENV QGIS_SERVER_LOG_LEVEL 0
 ENV QGIS_DEBUG 1
 
+ENV PROCESSES 1
+
 USER qgis
 WORKDIR /home/qgis
 
-CMD ["/tini", "--", "xvfb-run", \
-     "spawn-fcgi", "-p", "5555", "-n", "-d", "/home/qgis", \
-     "/usr/lib/cgi-bin/qgis_mapserv.fcgi"]
+ENTRYPOINT ["/tini", "--"]
+
+CMD ["sh", "-c", "xvfb-run spawn-fcgi -p 5555 -n -d /home/qgis -- /usr/bin/multiwatch -f $PROCESSES -- /usr/lib/cgi-bin/qgis_mapserv.fcgi"]

--- a/qgis-exec/Dockerfile-official
+++ b/qgis-exec/Dockerfile-official
@@ -10,10 +10,11 @@ RUN apt-get update \
     && echo "deb http://qgis.org/debian stretch main" >> /etc/apt/sources.list.d/qgis.list \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
+        multiwatch \
+        qgis-server \
+        spawn-fcgi \
         xauth \
         xvfb \
-        spawn-fcgi \
-        qgis-server \
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m qgis
@@ -27,9 +28,11 @@ ENV QGIS_SERVER_LOG_FILE /var/log/qgisserver.log
 ENV QGIS_SERVER_LOG_LEVEL 0
 ENV QGIS_DEBUG 1
 
+ENV PROCESSES 1
+
 USER qgis
 WORKDIR /home/qgis
 
-CMD ["/tini", "--", "xvfb-run", \
-     "spawn-fcgi", "-p", "5555", "-n", "-d", "/home/qgis", \
-     "/usr/lib/cgi-bin/qgis_mapserv.fcgi"]
+ENTRYPOINT ["/tini", "--"]
+
+CMD ["sh", "-c", "xvfb-run spawn-fcgi -p 5555 -n -d /home/qgis -- /usr/bin/multiwatch -f $PROCESSES -- /usr/lib/cgi-bin/qgis_mapserv.fcgi"]

--- a/qgis-exec/docker-compose.yml
+++ b/qgis-exec/docker-compose.yml
@@ -19,5 +19,6 @@ services:
     - ./data:/data:ro
     environment:
     - QGIS_PROJECT_FILE=/data/osm.qgs
+    - PROCESSES=4
 networks:
   qgis: {}


### PR DESCRIPTION
This PR changes qgis-exec/Dockerfile to make it possible to specify the number of processes to use for the execution of QGIS Server. This is done through the `PROCESSES` environment variable.

