### PR TITLE
Move command in a cmd.sh script

### DIFF
--- a/qgis-exec/Dockerfile
+++ b/qgis-exec/Dockerfile
@@ -37,9 +37,11 @@ ENV QGIS_DEBUG 1
 
 ENV PROCESSES 1
 
+COPY --chown=qgis:qgis cmd.sh /home/qgis/cmd.sh
+
 USER qgis
 WORKDIR /home/qgis
 
 ENTRYPOINT ["/tini", "--"]
 
-CMD ["sh", "-c", "xvfb-run spawn-fcgi -p 5555 -n -d /home/qgis -- /usr/bin/multiwatch -f $PROCESSES -- /usr/lib/cgi-bin/qgis_mapserv.fcgi"]
+CMD ["/home/qgis/cmd.sh"]

--- a/qgis-exec/Dockerfile-official
+++ b/qgis-exec/Dockerfile-official
@@ -30,9 +30,11 @@ ENV QGIS_DEBUG 1
 
 ENV PROCESSES 1
 
+COPY --chown=qgis:qgis cmd.sh /home/qgis/cmd.sh
+
 USER qgis
 WORKDIR /home/qgis
 
 ENTRYPOINT ["/tini", "--"]
 
-CMD ["sh", "-c", "xvfb-run spawn-fcgi -p 5555 -n -d /home/qgis -- /usr/bin/multiwatch -f $PROCESSES -- /usr/lib/cgi-bin/qgis_mapserv.fcgi"]
+CMD ["/home/qgis/cmd.sh"]

--- a/qgis-exec/cmd.sh
+++ b/qgis-exec/cmd.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+[[ $DEBUG == "1" ]] && env
+
+exec /usr/bin/xvfb-run /usr/bin/spawn-fcgi -p 5555 -n -d /home/qgis -- /usr/bin/multiwatch -f $PROCESSES -- /usr/lib/cgi-bin/qgis_mapserv.fcgi

--- a/qgis-exec/docker-compose.yml
+++ b/qgis-exec/docker-compose.yml
@@ -20,5 +20,6 @@ services:
     environment:
     - QGIS_PROJECT_FILE=/data/osm.qgs
     - PROCESSES=4
+    # - DEBUG=1  # display environment before spawning QGIS Server
 networks:
   qgis: {}

--- a/qgis-exec/docker-compose.yml
+++ b/qgis-exec/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     - ./data:/data:ro
     environment:
     - QGIS_PROJECT_FILE=/data/osm.qgs
-    - PROCESSES=4
+    - PROCESSES=1
     # - DEBUG=1  # display environment before spawning QGIS Server
 networks:
   qgis: {}


### PR DESCRIPTION
This is to ease debugging, and avoid duplicating the whole command line in Dockerfile-official.