### PR TITLE
Build QGIS without creating Debian packages

### DIFF
--- a/qgis-build/Dockerfile
+++ b/qgis-build/Dockerfile
@@ -94,9 +94,11 @@ RUN apt-get update \
         xvfb \
     && rm -rf /var/lib/apt/lists/*
 
-COPY build.sh /build.sh
-RUN chmod u+x /build.sh
+COPY build.sh build-debs.sh /
+RUN chmod a+x /build.sh /build-debs.sh
 
 ENV DIST stretch
 
-CMD ["/build.sh"]
+WORKDIR /qgis/QGIS
+
+CMD ["/build-debs.sh"]

--- a/qgis-build/README.md
+++ b/qgis-build/README.md
@@ -47,3 +47,18 @@ Notes:
 * `-e CCACHE_DIR=/.ccache` is used to set the `CCACHE_DIR` envvar to `/.ccache` for the compilation
 
 After the build completes you should find Debian packages (`.deb` files) in the `build` directory.
+
+## Advanced
+
+By default, when running `docker run qgis-build`, the image's `/build-deb.sh` script is executed.
+That script uses the `dch` and `dpkg-buildpackage` commands to build Debian packages for QGIS.
+
+If you just want to compile QGIS and don't want Debian packages you can change the command at
+`docker run` time and use `bash` instead of the default `/build-deb.sh` script:
+
+```shell
+$ docker run -it --rm -v $(pwd):/qgis -v $HOME/.ccache:/.ccache -u $(id -u):$(id -g) -e CCACHE_DIR=/.ccache qgis-build bash
+```
+
+At this point you can execute the images's `/build.sh` script for building and installing QGIS using
+`cmake` and `make`. Or you can execute the build commands of your choice.

--- a/qgis-build/build-debs.sh
+++ b/qgis-build/build-debs.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# --pre-clean
+# --post-clean
+
+set -e
+
+export DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS} nocheck"  # for dpkg-buildpackage
+
+cd /qgis/QGIS
+dch -l ~${DIST} --force-distribution --distribution ${DIST} "${DIST} build"
+dpkg-buildpackage -us -uc -b $@
+
+exit 0

--- a/qgis-build/build.sh
+++ b/qgis-build/build.sh
@@ -2,8 +2,28 @@
 
 set -e
 
-cd /qgis/QGIS
-dch -l ~${DIST} --force-distribution --distribution ${DIST} "${DIST} build"
-DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -us -uc -b --pre-clean --post-clean
+ROOT="/qgis"
+QGIS="${ROOT}/QGIS"
+BUILD="${QGIS}/build"
+INSTALL="${ROOT}/install"
+
+mkdir -p ${BUILD}
+mkdir -p ${DIST}
+
+cd ${BUILD}
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=${INSTALL} \
+      -DCMAKE_VERBOSE_MAKEFILE=ON \
+      -DWITH_DESKTOP=OFF \
+      -DWITH_SERVER=ON \
+      -DWITH_SERVER_PLUGINS=ON \
+      -DSERVER_SKIP_ECW=ON \
+      -DSUPPRESS_QT_WARNINGS=ON \
+      -DENABLE_TESTS=OFF \
+      -DWITH_ASTYLE=OFF \
+      -DWITH_APIDOC=OFF \
+      ${QGIS}
+make $@
+make install
 
 exit 0


### PR DESCRIPTION
This provides documentations and a helper script for building QGIS without actually creating Debian packages.