### PR TITLE
qgis-exec: fix Docker restart

### DIFF
--- a/qgis-exec/cmd.sh
+++ b/qgis-exec/cmd.sh
@@ -8,4 +8,4 @@ else
     MULTIWATCH=""
 fi
 
-exec /usr/bin/xvfb-run /usr/bin/spawn-fcgi -p 5555 -n -d /home/qgis -- $MULTIWATCH /usr/lib/cgi-bin/qgis_mapserv.fcgi
+exec /usr/bin/xvfb-run --auto-servernum --server-num=1 /usr/bin/spawn-fcgi -p 5555 -n -d /home/qgis -- $MULTIWATCH /usr/lib/cgi-bin/qgis_mapserv.fcgi


### PR DESCRIPTION
This fixes `docker restart` for the qgis-exec container. Thank you @pblottiere for the tip!