### PR TITLE
Support current qgis master

### DIFF
--- a/qgis-build/Dockerfile
+++ b/qgis-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 RUN apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
@@ -19,6 +19,7 @@ RUN apt-get update \
         graphviz \
         grass-dev \
         libdistro-info-perl \
+        libexiv2-dev \
         libexpat1-dev \
         libfcgi-dev \
         libgdal-dev \
@@ -45,6 +46,7 @@ RUN apt-get update \
         lighttpd \
         locales \
         ninja-build \
+        ocl-icd-opencl-dev \
         opencl-headers \
         pkg-config \
         poppler-utils \
@@ -84,6 +86,7 @@ RUN apt-get update \
         qtpositioning5-dev \
         qttools5-dev \
         qttools5-dev-tools \
+        saga \
         spawn-fcgi \
         txt2tags \
         xauth \

--- a/qgis-build/README.md
+++ b/qgis-build/README.md
@@ -30,6 +30,12 @@ $ cd build
 $ git clone https://github.com/qgis/QGIS.git
 ```
 
+Create a directory `.ccache` in your home dir if you don't have one already:
+
+```shell
+$ mkdir $HOME/.ccache
+```
+
 Build QGIS:
 
 ```shell

--- a/qgis-exec/Dockerfile
+++ b/qgis-exec/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 COPY deb/libqgis-analysis*.deb \
      deb/libqgis-app*.deb \

--- a/qgis-exec/map.html
+++ b/qgis-exec/map.html
@@ -3,7 +3,7 @@
 <html>
   <head>
     <title>QGIS Docker OSM Example</title>
-    <link rel="stylesheet" href="https://openlayers.org/en/v4.6.4/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
     <!-- The line below is only needed for old environments like Internet Explorer and Android 4.x -->
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL"></script>
     <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>


### PR DESCRIPTION
The current QGIS master code requires Debian buster, and additional build dependencies. This PR brings the required changes.