### PR TITLE
Make build type configurable

### DIFF
--- a/qgis-build/Dockerfile
+++ b/qgis-build/Dockerfile
@@ -100,7 +100,7 @@ RUN apt-get update \
 COPY build.sh build-debs.sh /
 RUN chmod a+x /build.sh /build-debs.sh
 
-ENV DIST stretch
+ENV DIST buster
 
 WORKDIR /qgis/QGIS
 

--- a/qgis-build/build.sh
+++ b/qgis-build/build.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+BUILD_TYPE=${BUILD_TYPE:-Release}
+
 ROOT="/qgis"
 QGIS="${ROOT}/QGIS"
 BUILD="${QGIS}/build"
@@ -11,7 +13,7 @@ mkdir -p ${BUILD}
 mkdir -p ${DIST}
 
 cd ${BUILD}
-cmake -DCMAKE_BUILD_TYPE=Release \
+cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
       -DCMAKE_INSTALL_PREFIX=${INSTALL} \
       -DCMAKE_VERBOSE_MAKEFILE=ON \
       -DWITH_DESKTOP=OFF \


### PR DESCRIPTION
Two changes to qgis-build:

* Change build.sh to make the build type configurable
* Fix issue in Dockerfile where the `DIST` envvar should be set to `buster`