### PR TITLE
Fixes for qgis-build and qgis-exec

### DIFF
--- a/qgis-build/build-debs.sh
+++ b/qgis-build/build-debs.sh
@@ -21,6 +21,9 @@ cd /qgis/QGIS
 dch -l ~${DIST} --force-distribution --distribution ${DIST} "${DIST} build"
 dpkg-buildpackage -us -uc -b $@
 if [[ -n "$USER" ]]; then
-    chown $USER /qgis/oracle-*deb /qgis/qgis*deb /qgis/libqgis*deb /qgis/qgis*buildinfo /qgis/qgis*changes /qgis/python*deb
+    chown $USER /qgis/qgis*deb /qgis/libqgis*deb /qgis/qgis*buildinfo /qgis/qgis*changes /qgis/python*deb
+    if [[ "${BUILD_ORACLE_PROVIDER}" = "y" ]]; then
+        chown $USER /qgis/oracle-*deb
+    fi
 fi
 exit 0

--- a/qgis-build/build.sh
+++ b/qgis-build/build.sh
@@ -24,6 +24,7 @@ cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
       -DENABLE_TESTS=OFF \
       -DWITH_ASTYLE=OFF \
       -DWITH_APIDOC=OFF \
+      -DENABLE_TESTS=ON \
       ${QGIS}
 make $@
 make install

--- a/qgis-exec/Dockerfile
+++ b/qgis-exec/Dockerfile
@@ -9,7 +9,9 @@ COPY deb/libqgis-analysis*.deb \
      deb/libqgis-native*.deb \
      deb/libqgispython*.deb \
      deb/libqgis-server*.deb \
+     deb/libqgis-3d*.deb \
      deb/python-qgis*.deb \
+     deb/python3-qgis*.deb \
      deb/qgis-common*.deb \
      deb/qgis-providers*.deb \
      deb/qgis-server*.deb \


### PR DESCRIPTION
This PR does three things (with three commits):

- avoid doing chown on the Oracle debs when BUILD_ORACLE_PROVIDER is not set
- use ENABLE_TESTS=ON in build.sh on the the cmake command line, which is required to be able to run the tests from the qgis-build container
- add the libqgis-3d and python3-qgis packages for the buiding of the qgis-exec image. This is now required for installing QGIS master